### PR TITLE
Point to latest commit, but not AUTOREV

### DIFF
--- a/recipes-kernel/isgx/isgx.bb
+++ b/recipes-kernel/isgx/isgx.bb
@@ -8,7 +8,7 @@ SRC_URI = "git://github.com/intel/linux-sgx-driver.git \
            file://0001-isgx-kernel-modules.patch \
           "
 
-SRCREV = "0b76a7c905b8293ef18414bd3a3a867059a1ceb6"
+SRCREV = "10a2f21142c7e452117c5b17ae85cb8be2f4f19b"
 S = "${WORKDIR}/git"
 KERNEL_MODULE_AUTOLOAD += "isgx"
 # The inherit of module.bbclass will automatically name module packages with


### PR DESCRIPTION
Update recipe to get driver bug fix for version 5.1 of the kernel. 