### PR TITLE
Fix Cxx11SGXDemo for g++ version 8.3.0.

### DIFF
--- a/recipes-bsp/sgx/sgx/Cxx11SGXDemo.patch
+++ b/recipes-bsp/sgx/sgx/Cxx11SGXDemo.patch
@@ -1,0 +1,36 @@
+--- a/SampleCode/Cxx11SGXDemo/Enclave/TrustedLibrary/Libcxx.cpp
++++ b/SampleCode/Cxx11SGXDemo/Enclave/TrustedLibrary/Libcxx.cpp
+@@ -72,27 +72,27 @@
+     printf("[Lambdas] Initial array using lambdas: { ");
+ 
+     // Print the elements in an array using lambdas
+-    std::for_each(std::begin(v), std::end(v), [](int elem) { printf("%d ", elem); }); //capture specification
++    std::for_each(v.begin(), v.end(), [](int elem) { printf("%d ", elem); }); //capture specification
+     printf("}.\n");
+ 
+     // Find the first odd number using lambda as an unary predicate when calling find_if.
+-    auto first_odd_element = std::find_if(std::begin(v), std::end(v), [=](int elem) { return elem % 2 == 1; });
++    auto first_odd_element = std::find_if(v.begin(), v.end(), [=](int elem) { return elem % 2 == 1; });
+ 
+-    if (first_odd_element != std::end(v))
++    if (first_odd_element != v.end())
+         printf("[Lambdas] First odd element in the array is %d. \n", *first_odd_element);
+     else
+         printf("[Lambdas] No odd element found in the array.\n");
+ 
+     // Count the even numbers using a lambda function as an unary predicate when calling count_if.
+-    long long  number_of_even_elements = std::count_if(std::begin(v), std::end(v), [=](int  val) { return val % 2 == 0; });
++    long long  number_of_even_elements = std::count_if(v.begin(), v.end(), [=](int  val) { return val % 2 == 0; });
+     printf("[Lambdas] Number of even elements in the array is %lld.\n", number_of_even_elements);
+ 
+     // Sort the elements of an array using lambdas
+-    std::sort(std::begin(v), std::end(v), [](int e1, int e2) {return e2 < e1; });
++    std::sort(v.begin(), v.end(), [](int e1, int e2) {return e2 < e1; });
+ 
+     // Print the elements in an array using lambdas
+     printf("[Lambdas] Array after sort: { ");
+-    std::for_each(std::begin(v), std::end(v), [](int elem) { printf("%d ", elem); });
++    std::for_each(v.begin(), v.end(), [](int elem) { printf("%d ", elem); });
+     printf("}. \n");
+     printf("\n"); // end of demo
+ }

--- a/recipes-bsp/sgx/sgx_2.2.bb
+++ b/recipes-bsp/sgx/sgx_2.2.bb
@@ -35,6 +35,7 @@ SRC_URI_append_class-target = " file://0001-Yocto-patch-for-SGX-2.0.patch \
     file://uninstall.sh \
     file://00021_sgx_target_build.patch \
     file://pcl_Makefile.patch \
+    file://Cxx11SGXDemo.patch \
 "
 
 SRC_URI[optimized_libs.md5sum] = "e5805206d5f75f510e60e3fbfe8e3a8f"


### PR DESCRIPTION
The yocto build for WHL has compile errors for the Cxx11SGXDemo application. This patch fixes these errors by changing std::begin(v) where v is a vector to v.begin(). Calls to std::end are also changed.