### PR TITLE
Runtime dependency on dmidecode utility

### DIFF
--- a/recipes-bsp/sgx/sgx_2.2.bb
+++ b/recipes-bsp/sgx/sgx_2.2.bb
@@ -293,8 +293,7 @@ SYSTEMD_SERVICE_${PN} = "aesmd.service"
 
 # Runtime dependencies
 RDEPENDS_${PN} += "bash"
-RDEPENDS_${PN}_x86 = "dmidecode"
-RDEPENDS_${PN}_x86-64 = "dmidecode"
+RDEPENDS_${PN}_class-target = "dmidecode"
 
 RRECOMMENDS_${PN} += "kernel-module-isgx"
 


### PR DESCRIPTION
The dmidecode utility is used by tools to validate Intel(R) SGX.
The dependency is on the target package.

Signed-off-by: Gary West <gary.west@intel.com>