### PR TITLE
fix sgx builds

### DIFF
--- a/recipes-bsp/sgx/sgx/0001-sgx-native-removed-werror.patch
+++ b/recipes-bsp/sgx/sgx/0001-sgx-native-removed-werror.patch
@@ -1,18 +1,32 @@
-From 6040c92f004cab15ab043ad354c47c88050be5ca Mon Sep 17 00:00:00 2001
+From 178a806eaec9ed0af10b7aacbc6465b2256a0667 Mon Sep 17 00:00:00 2001
 From: "Lian, Da (Landau)" <da.lian@intel.com>
 Date: Thu, 30 Nov 2017 23:02:21 +0800
-Subject: [PATCH] sgx native removed werror
+Subject: [PATCH] sgx removed werror
 
 Upstream-Status: Inappropriate [embedded-specific]
 
 Signed-off-by: Lian, Da (Landau) <da.lian@intel.com>
 ---
+ psw/uae_service/linux/Makefile  | 2 +-
  psw/urts/parser/Makefile        | 4 ----
  sdk/sign_tool/SignTool/Makefile | 3 ---
- 2 files changed, 7 deletions(-)
+ 3 files changed, 1 insertion(+), 8 deletions(-)
 
+diff --git a/psw/uae_service/linux/Makefile b/psw/uae_service/linux/Makefile
+index 8a662e8f..c348446d 100644
+--- a/psw/uae_service/linux/Makefile
++++ b/psw/uae_service/linux/Makefile
+@@ -57,7 +57,7 @@ INCLUDE += -I$(LINUX_EXTERNAL_DIR)/epid-sdk    \
+            -I$(IPC_COMMON_PROTO_DIR) \
+            -I$(LINUX_PSW_DIR)/ae/aesm_service/source
+ 
+-CXXFLAGS += -fPIC -Werror -Wno-unused-parameter -g -DPROTOBUF_INLINE_NOT_IN_HEADERS=0
++CXXFLAGS += -fPIC -Wno-unused-parameter -g -DPROTOBUF_INLINE_NOT_IN_HEADERS=0
+ 
+ EXTERNAL_LIB += -lprotobuf 
+  
 diff --git a/psw/urts/parser/Makefile b/psw/urts/parser/Makefile
-index 6bd41ea..1a54a44 100644
+index 44d0d533..fd56894f 100644
 --- a/psw/urts/parser/Makefile
 +++ b/psw/urts/parser/Makefile
 @@ -39,10 +39,6 @@ TARGET := libenclaveparser.a
@@ -27,7 +41,7 @@ index 6bd41ea..1a54a44 100644
              -I$(COMMON_DIR)/inc/internal \
              -I.                          \
 diff --git a/sdk/sign_tool/SignTool/Makefile b/sdk/sign_tool/SignTool/Makefile
-index 7ac7aaa..7360271 100644
+index 3d181882..2f5a9469 100644
 --- a/sdk/sign_tool/SignTool/Makefile
 +++ b/sdk/sign_tool/SignTool/Makefile
 @@ -31,9 +31,6 @@
@@ -41,5 +55,5 @@ index 7ac7aaa..7360271 100644
  CXXFLAGS += -fpie
  LDFLAGS := -pie $(COMMON_LDFLAGS)
 -- 
-2.7.4
+2.24.1
 

--- a/recipes-bsp/sgx/sgx/0001-sgx-patch-makefile-to-point-to-correct-ocaml-libs.patch
+++ b/recipes-bsp/sgx/sgx/0001-sgx-patch-makefile-to-point-to-correct-ocaml-libs.patch
@@ -1,0 +1,46 @@
+From 65c866ec56cdc8d7beea3df5e0fc50d7ad483c93 Mon Sep 17 00:00:00 2001
+From: Anuj Mittal <anuj.mittal@intel.com>
+Date: Wed, 11 Mar 2020 12:07:12 +0800
+Subject: [PATCH] sgx: patch makefile to point to correct ocaml libs
+
+fixes:
+
+    | ocamlc.opt -c -ccopt -fpie -o Ast.cmo Ast.ml
+    | + ocamlc.opt -c -ccopt -fpie -o Ast.cmo Ast.ml
+    | File "command line", line 1:
+    | Error: Unbound module Pervasives
+    | Command exited with code 2.
+    | Hint: Recursive traversal of subdirectories was not enabled for this build,
+    |   as the working directory does not look like an ocamlbuild project (no
+    |   '_tags' or 'myocamlbuild.ml' file). If you have modules in subdirectories,
+    |   you should add the option "-r" or create an empty '_tags' file.
+    |
+    |   To enable recursive traversal for some subdirectories only, you can use the
+    |   following '_tags' file:
+    |
+    |       true: -traverse
+    |       <dir1> or <dir2>: traverse
+    |
+    | make: *** [Makefile:48: build] Error 10
+
+Signed-off-by: Anuj Mittal <anuj.mittal@intel.com>
+---
+ sdk/edger8r/linux/Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/sdk/edger8r/linux/Makefile b/sdk/edger8r/linux/Makefile
+index 4706cacc..9ffde000 100644
+--- a/sdk/edger8r/linux/Makefile
++++ b/sdk/edger8r/linux/Makefile
+@@ -45,7 +45,7 @@ build:
+ ifeq ($(shell test $(OCAML_VERSION) -lt 402 && echo 1), 1)
+ 	ocamlbuild -lflag -ccopt -lflag "-Wl,-z,now" -no-links -libs str,unix  Edger8r.native
+ else
+-	ocamlbuild -cflags -ccopt,-fpie -lflags -runtime-variant,_pic,-ccopt,-pie,-ccopt -lflag "-Wl,-z,now"  -no-links -libs str,unix Edger8r.native
++	ocamlbuild -cflags -I,${OCAML_NATIVE_LIB} -lflags -I,${OCAML_NATIVE_LIB} -cflags -ccopt,-fpie -lflags -runtime-variant,_pic,-ccopt,-pie,-ccopt -lflag "-Wl,-z,now"  -no-links -libs str,unix Edger8r.native
+ endif
+ 
+ $(BUILD_DIR):
+-- 
+2.24.1
+

--- a/recipes-bsp/sgx/sgx/0001-sgx-target-patch-makefile-to-point-to-correct-ocaml-.patch
+++ b/recipes-bsp/sgx/sgx/0001-sgx-target-patch-makefile-to-point-to-correct-ocaml-.patch
@@ -1,0 +1,46 @@
+From f0e884db177d38567e9edfd7d522578cfe4dd593 Mon Sep 17 00:00:00 2001
+From: Anuj Mittal <anuj.mittal@intel.com>
+Date: Wed, 11 Mar 2020 12:16:51 +0800
+Subject: [PATCH] sgx: target: patch makefile to point to correct ocaml libs
+
+fixes:
+
+    | ocamlc.opt -c -ccopt -fpie -o Ast.cmo Ast.ml
+    | + ocamlc.opt -c -ccopt -fpie -o Ast.cmo Ast.ml
+    | File "command line", line 1:
+    | Error: Unbound module Pervasives
+    | Command exited with code 2.
+    | Hint: Recursive traversal of subdirectories was not enabled for this build,
+    |   as the working directory does not look like an ocamlbuild project (no
+    |   '_tags' or 'myocamlbuild.ml' file). If you have modules in subdirectories,
+    |   you should add the option "-r" or create an empty '_tags' file.
+    |
+    |   To enable recursive traversal for some subdirectories only, you can use the
+    |   following '_tags' file:
+    |
+    |       true: -traverse
+    |       <dir1> or <dir2>: traverse
+    |
+    | make: *** [Makefile:48: build] Error 10
+
+Signed-off-by: Anuj Mittal <anuj.mittal@intel.com>
+---
+ sdk/edger8r/linux/Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/sdk/edger8r/linux/Makefile b/sdk/edger8r/linux/Makefile
+index 8096805a..d66b2404 100644
+--- a/sdk/edger8r/linux/Makefile
++++ b/sdk/edger8r/linux/Makefile
+@@ -45,7 +45,7 @@ build:
+ ifeq ($(shell test $(OCAML_VERSION) -lt 402 && echo 1), 1)
+ 	ocamlbuild -lflag -ccopt -lflag "-Wl,-z,now" -no-links -libs str,unix -lflags -cc,$(CCONLY) $(CCOPTS) $(LDOPTS) Edger8r.native
+ else
+-	ocamlbuild -cflags -ccopt,-fpie -lflags -runtime-variant,_pic,-ccopt,-pie,-ccopt -lflag "-Wl,-z,now"  -no-links -libs str,unix -lflags -cc,$(CCONLY) $(CCOPTS) $(LDOPTS) Edger8r.native
++	ocamlbuild -cflags -I,$(OCAML_NATIVE_LIB) -lflags -I,$(OCAML_NATIVE_LIB) -cflags -ccopt,-fpie -lflags -runtime-variant,_pic,-ccopt,-pie,-ccopt -lflag "-Wl,-z,now"  -no-links -libs str,unix -lflags -cc,$(CCONLY) $(CCOPTS) $(LDOPTS) Edger8r.native
+ endif
+ 
+ $(BUILD_DIR):
+-- 
+2.24.1
+

--- a/recipes-bsp/sgx/sgx_2.2.bb
+++ b/recipes-bsp/sgx/sgx_2.2.bb
@@ -24,9 +24,10 @@ LIC_FILES_CHKSUM = "file://License.txt;md5=c7a6a2fa753b1403cdbc7f1d14e11f65"
 SRC_URI = "git://github.com/intel/linux-sgx.git \
     https://download.01.org/intel-sgx/linux-2.3/optimized_libs_2.3.tar.gz;subdir=${S};name=optimized_libs \
     https://download.01.org/intel-sgx/linux-2.3/prebuilt_ae_2.3.tar.gz;subdir=${S};name=prebuilt_ae \
+    file://0001-sgx-native-removed-werror.patch \
 "
 
-SRC_URI_append_class-native = " file://0001-sgx-native-removed-werror.patch \
+SRC_URI_append_class-native = " \
                                 file://0001-sgx-patch-makefile-to-point-to-correct-ocaml-libs.patch \
                                 "
 

--- a/recipes-bsp/sgx/sgx_2.2.bb
+++ b/recipes-bsp/sgx/sgx_2.2.bb
@@ -26,7 +26,9 @@ SRC_URI = "git://github.com/intel/linux-sgx.git \
     https://download.01.org/intel-sgx/linux-2.3/prebuilt_ae_2.3.tar.gz;subdir=${S};name=prebuilt_ae \
 "
 
-SRC_URI_append_class-native = " file://0001-sgx-native-removed-werror.patch"
+SRC_URI_append_class-native = " file://0001-sgx-native-removed-werror.patch \
+                                file://0001-sgx-patch-makefile-to-point-to-correct-ocaml-libs.patch \
+                                "
 
 SRC_URI_append_class-target = " file://0001-Yocto-patch-for-SGX-2.0.patch \
     file://0001-Sample-Code-patch.patch \
@@ -37,6 +39,7 @@ SRC_URI_append_class-target = " file://0001-Yocto-patch-for-SGX-2.0.patch \
     file://pcl_Makefile.patch \
     file://Cxx11SGXDemo.patch \
     file://GCC9-warnings.patch \
+    file://0001-sgx-target-patch-makefile-to-point-to-correct-ocaml-.patch \
 "
 
 SRC_URI[optimized_libs.md5sum] = "e5805206d5f75f510e60e3fbfe8e3a8f"
@@ -64,6 +67,7 @@ python () {
 EXTRA_OEMAKE_class-target = "CCONLY='${CCONLY}' CCOPTS='${CCOPTS}' LDOPTS='${LDOPTS}' 'MODE=HW' 'psw'"
 # Debug build
 #EXTRA_OEMAKE_class-target_append = " 'DEBUG=1'"
+EXTRA_OEMAKE_append = " OCAML_NATIVE_LIB='${STAGING_LIBDIR_NATIVE}'"
 
 CXXFLAGS_append = " -std=c++0x ${LDFLAGS}"
 

--- a/recipes-devtools/ocaml/ocaml_4.02.3.bb
+++ b/recipes-devtools/ocaml/ocaml_4.02.3.bb
@@ -32,6 +32,10 @@ PARALLEL_MAKEINST = ""
 do_install_class-native () {
     oe_runmake install DESTDIR=${D}
     oe_runmake install
+
+    for s in `find ${D}${bindir} -type f`; do
+        sed -i -e "1s,#!.*ocamlrun.*,#!${USRBINPATH}/env ocamlrun," ${s}
+    done
 }
 
 BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
sgx tries to use ocaml-native binaries which are pointing to interpreter and libs in it's own $D. Fix the paths and pass correct libdir explicitly.

There are separate patches for native and target unfortunately because we already patch the makefile for target.