### PR TITLE
conf/layer.conf: add support for Yocto 3.1 (dunfell)

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -17,6 +17,6 @@ LAYERDEPENDS_sgx = "core openembedded-layer"
 # Override security flags
 require conf/distro/include/meta_intel_sgx_security_flags.inc
 
-LAYERSERIES_COMPAT_sgx = "sumo thud warrior zeus"
+LAYERSERIES_COMPAT_sgx = "sumo thud warrior zeus dunfell"
 
 LICENSE_PATH += "${LAYERDIR}/custom-licenses"


### PR DESCRIPTION
Support for Yocto 3.1 (dunfell) added.

Signed-off-by: Kartikey Rameshbhai Parmar <kartikey.rameshbhai.parmar@intel.com>