### PR TITLE
Convert to new override syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Add the following to local.conf in order to enable Intel(R) SGX PSW:
 
 ```
 # Enable Intel(R) SGX PSW support.
-IMAGE_INSTALL_append = " sgx"
+IMAGE_INSTALL:append = " sgx"
 ```
 
 Add the following to local.conf in order to enable Intel(R) SGX PSW and
@@ -69,7 +69,7 @@ SGX SDK:
 
 ```
 # Enable Intel(R) SGX PSW & SDK support.  
-IMAGE_INSTALL_append = " sgx-dev"
+IMAGE_INSTALL:append = " sgx-dev"
 ```
 
 #### Step 2/2) Enable the driver
@@ -85,7 +85,7 @@ out-of-tree ('isgx') driver must be used. To use the SGX out-of-tree
 driver, add the following line to local.conf:  
 
 ```
-IMAGE_INSTALL_append = " isgx"
+IMAGE_INSTALL:append = " isgx"
 ```
 
 On the other hand, if you choose to pick the Unlocked Mode, then SGX
@@ -93,7 +93,7 @@ in-kernel driver must be used. To use the in-kernel SGX driver, add the
 following to local.conf:
 
 ```
-DISTRO_FEATURES_append = " sgx"
+DISTRO_FEATURES:append = " sgx"
 ```
 
 ## Copying

--- a/conf/distro/include/meta_intel_sgx_security_flags.inc
+++ b/conf/distro/include/meta_intel_sgx_security_flags.inc
@@ -1,2 +1,2 @@
 # Build errors with the pie options enabled
-SECURITY_CFLAGS_pn-protobuf = "${SECURITY_NO_PIE_CFLAGS}"
+SECURITY_CFLAGS:pn-protobuf = "${SECURITY_NO_PIE_CFLAGS}"

--- a/recipes-bsp/sgx/sgx-common_2.12.inc
+++ b/recipes-bsp/sgx/sgx-common_2.12.inc
@@ -13,8 +13,8 @@ LICENSE = " \
 LIC_FILES_CHKSUM = "file://License.txt;md5=a126e7fbbb897ad5819596908b509eae"
 
 # Packages required to build
-DEPENDS_append = " openssl-native cmake-native"
-DEPENDS_append_class-target = " openssl"
+DEPENDS:append = " openssl-native cmake-native"
+DEPENDS:append:class-target = " openssl"
 
 # Parallel make does not work with some recipes
 PARALLEL_MAKE = ""
@@ -34,8 +34,8 @@ export BUILD_SYS
 export TARGET_SYS
 
 # SGX environment variables
-sgxdirprefix_class-native = "${RECIPE_SYSROOT_NATIVE}"
-sgxdirprefix_class-target = ""
+sgxdirprefix:class-native = "${RECIPE_SYSROOT_NATIVE}"
+sgxdirprefix:class-target = ""
 sgxrootdir = "/opt/intel"
 
 sgxsdkbase = "sgxsdk"

--- a/recipes-bsp/sgx/sgx-dcap_1.9.bb
+++ b/recipes-bsp/sgx/sgx-dcap_1.9.bb
@@ -73,7 +73,7 @@ do_configure () {
 # Build target(s)
 EXTRA_OEMAKE += "QuoteGeneration"
 
-do_compile_prepend () {
+do_compile:prepend () {
     export SGX_SDK="${RECIPE_SYSROOT}/opt/intel/sgxsdk-cross"
     export PATH=$PATH:$SGX_SDK/bin:$SGX_SDK/bin/x64
 }
@@ -89,7 +89,7 @@ do_install () {
 ### package ###
 
 SYSROOT_DIRS += "/opt/intel"
-FILES_${PN}  += "/opt/intel"
+FILES:${PN}  += "/opt/intel"
 
 ### ###
 

--- a/recipes-bsp/sgx/sgx-sdk-cross_2.12.bb
+++ b/recipes-bsp/sgx/sgx-sdk-cross_2.12.bb
@@ -37,7 +37,7 @@ do_install () {
 ### ###
 
 SYSROOT_DIRS += "${sgxdirprefix}${sgxsdkpath}-cross"
-FILES_${PN}-dev += "${sgxsdkpath}-cross"
+FILES:${PN}-dev += "${sgxsdkpath}-cross"
 
 CVE_PRODUCT = "software_guard_extensions_sdk"
 

--- a/recipes-bsp/sgx/sgx-sdk_2.12.bb
+++ b/recipes-bsp/sgx/sgx-sdk_2.12.bb
@@ -32,7 +32,7 @@ do_install () {
 
 SYSROOT_DIRS += "${sgxdirprefix}${sgxrootdir}/package"
 
-FILES_${PN}-dev += "${sgxrootdir}"
+FILES:${PN}-dev += "${sgxrootdir}"
 
 ### ###
 

--- a/recipes-bsp/sgx/sgx-source_2.12.inc
+++ b/recipes-bsp/sgx/sgx-source_2.12.inc
@@ -24,7 +24,7 @@ SRC_URI += "file://0003-default-python.patch"
 
 ### configure ###
 
-do_configure_prepend () {
+do_configure:prepend () {
     # SRC_URI is located at ${S}
 
     # optimized libs are unpacke in ${S}

--- a/recipes-bsp/sgx/sgx_2.12.bb
+++ b/recipes-bsp/sgx/sgx_2.12.bb
@@ -20,7 +20,7 @@ SRC_URI += " \
 # Build target(s)
 EXTRA_OEMAKE += "psw_install_pkg"
 
-do_compile_prepend () {
+do_compile:prepend () {
     export SGX_SDK="${RECIPE_SYSROOT}${sgxsdkpath}-cross"
     export PATH=$PATH:$SGX_SDK/bin:$SGX_SDK/bin/x64
 }
@@ -39,10 +39,10 @@ do_install () {
 ### package ###
 
 SYSROOT_DIRS += "${sgxrootdir}"
-FILES_${PN}  += "${sgxrootdir}"
+FILES:${PN}  += "${sgxrootdir}"
 
 #Script or implement install on first boot.
-pkg_postinst_ontarget_${PN} () {
+pkg_postinst_ontarget:${PN} () {
     # Verify on target
     if [ -z "$D" ]; then
 
@@ -71,7 +71,7 @@ pkg_postinst_ontarget_${PN} () {
 ### ###
 
 # Runtime dependencies
-RDEPENDS_${PN} += "bash"
+RDEPENDS:${PN} += "bash"
 
 CVE_PRODUCT = "software_guard_extensions_platform"
 

--- a/recipes-devtools/cppmicroservices/cppmicroservices_4.0.bb
+++ b/recipes-devtools/cppmicroservices/cppmicroservices_4.0.bb
@@ -6,7 +6,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 # Packages required to build
-DEPENDS_append_class-target += "cppmicroservices-native"
+DEPENDS:append:class-target += "cppmicroservices-native"
 
 # Parallel make does not work with some recipes
 PARALLEL_MAKE = ""
@@ -19,7 +19,7 @@ SRC_URI = "gitsm://github.com/intel/linux-sgx.git"
 SRCREV = "a21f2d9dd77e7672b00f99f9b61bc81cc44e5954"
 
 # Patches
-SRC_URI_append_class-target += "file://0001-host-bin.patch"
+SRC_URI:append:class-target += "file://0001-host-bin.patch"
 
 # Source directory
 S = "${WORKDIR}/git/external/CppMicroServices"
@@ -33,21 +33,21 @@ INHIBIT_PACKAGE_DEBUG_SPLIT  = "1"
 HOST_BIN = "${datadir}/cppmicroservices4/host_bin"
 
 EXTRA_OECMAKE += "-DCMAKE_BUILD_TYPE=RelWithDebInfo"
-EXTRA_OECMAKE_append_class-target += "-DCMAKE_HOST_BINARY_DIR:PATH=${RECIPE_SYSROOT_NATIVE}${HOST_BIN}"
+EXTRA_OECMAKE:append:class-target += "-DCMAKE_HOST_BINARY_DIR:PATH=${RECIPE_SYSROOT_NATIVE}${HOST_BIN}"
 
 ### install ###
 
-do_install_append () {
+do_install:append () {
     rm -rfv ${D}${libdir}/.debug
 }
 
-do_install_append_class-native () {
+do_install:append:class-native () {
     install -d "${D}${datadir}/cppmicroservices4/host_bin"
     install -m 0644 "${B}/ImportExecutables.cmake" "${D}${HOST_BIN}"
     install -m 0755 "${B}/bin/usResourceCompiler4" "${D}${HOST_BIN}"
 }
 
-do_install_append_class-target () {
+do_install:append:class-target () {
     if [ "${libdir}" != "/usr/lib" ]; then
         mv ${D}/usr/lib ${D}${libdir}
     fi
@@ -55,7 +55,7 @@ do_install_append_class-target () {
 
 ### package ###
 
-FILES_${PN} = "${bindir} ${libdir} ${datadir}"
+FILES:${PN} = "${bindir} ${libdir} ${datadir}"
 
 ### ###
 

--- a/recipes-devtools/gdb/gdb_%.bbappend
+++ b/recipes-devtools/gdb/gdb_%.bbappend
@@ -1,1 +1,1 @@
-PACKAGECONFIG_append = " python"
+PACKAGECONFIG:append = " python"

--- a/recipes-kernel/intelsgx/intelsgx.bb
+++ b/recipes-kernel/intelsgx/intelsgx.bb
@@ -13,5 +13,5 @@ SRCREV = "98976322e8b58e23256355f5cf90b9e30e37d8c1"
 
 S = "${WORKDIR}/git/driver/linux"
 
-RPROVIDES_${PN} += "kernel-module-${PN}"
+RPROVIDES:${PN} += "kernel-module-${PN}"
 

--- a/recipes-kernel/linux/linux-%.bbappend
+++ b/recipes-kernel/linux/linux-%.bbappend
@@ -1,4 +1,4 @@
-FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 ## Enable sgx in the Linux kernel if sgx is included in DISTRO_FEATURES.
 SGX_CONFIG_URI += "\
@@ -8,4 +8,4 @@ SGX_CONFIG_URI += "\
 # Only append to source URI if a kernel recipe is being bbappend'ed.
 # Note that there exists recipe names that start with "linux-",
 # for example, linux-libc-headers, linux-firmware, etc.
-SRC_URI_append = "${@d.getVar('SGX_CONFIG_URI') if bb.data.inherits_class('kernel', d) else ''}"
+SRC_URI:append = "${@d.getVar('SGX_CONFIG_URI') if bb.data.inherits_class('kernel', d) else ''}"


### PR DESCRIPTION
The script is available in oe-core at scripts/contrib/convert-overrides.py.
This is to fix error with latest bitbake version.

Signed-off-by: Preeti Sachan <preeti.sachan@intel.com>