### PR TITLE
Fix license issue

### DIFF
--- a/recipes-bsp/sgx/sgx-common_2.18.1.inc
+++ b/recipes-bsp/sgx/sgx-common_2.18.1.inc
@@ -7,7 +7,7 @@ LICENSE = " \
   Intel-Sample-Source-Code & \
   MIT & \
   STLPort & \
-  BSD & \
+  BSD-3-Clause & \
   EPL-1.0 \
 "
 LIC_FILES_CHKSUM = "file://License.txt;md5=4af23fbd783d5ab20d55ba56c0b7b894"

--- a/recipes-bsp/sgx/sgx-dcap_1.15.bb
+++ b/recipes-bsp/sgx/sgx-dcap_1.15.bb
@@ -4,7 +4,7 @@
 ### common ###
 
 SUMMARY = "Intel(R) SGX Data Center Attestation Primitives (DCAP) driver"
-LICENSE = "BSD & Intel-Redistributable-Binaries"
+LICENSE = "BSD-3-Clause & Intel-Redistributable-Binaries"
 LIC_FILES_CHKSUM = "file://License.txt;md5=92c8e45a85591e3c219bceebaad7235e"
 
 inherit pkgconfig


### PR DESCRIPTION
Update to BSD clause 3 from the master commit

https://github.com/intel/linux-sgx
42cb30a7cd50d4addbd194a25b33118df6883cc1

https://github.com/intel/SGXDataCenterAttestationPrimitives 7613d4e7721668f74ed032305998dfbc49c67eb4

Update license of Intel signed architecture enclaves Now they are licensed under the 3-clause BSD license.