### PR TITLE
sgx: psw: Created complete set of links for shared objects.

### DIFF
--- a/recipes-bsp/sgx/files/fix_link.patch
+++ b/recipes-bsp/sgx/files/fix_link.patch
@@ -1,0 +1,17 @@
+diff --git a/linux/installer/common/psw/Makefile b/linux/installer/common/psw/Makefile
+index 1486ee1f..9ffc00b7 100644
+--- a/linux/installer/common/psw/Makefile
++++ b/linux/installer/common/psw/Makefile
+@@ -82,4 +82,11 @@ install:
+ 	ln -fs libsgx_quote_ex.so.$(call SPLIT_VERSION,$(QEX_VER),1) libsgx_quote_ex.so
+ 	cd $(INSTALL_PATH)/aesm && \
+ 	ln -fs liburts_internal.so libsgx_urts.so.$(call SPLIT_VERSION,$(URTS_VER),1) && \
+-	ln -fs libsgx_qe3_logic.so.$(call SPLIT_VERSION,$(QE3L_VER),1) libsgx_qe3_logic.so
++	ln -fs libsgx_qe3_logic.so.$(call SPLIT_VERSION,$(QE3L_VER),1) libsgx_qe3_logic.so &&\
++	ln -fs libsgx_qe3.signed.so.1 libsgx_qe3.signed.so && \
++	ln -fs libsgx_qe.signed.so.1 libsgx_qe.signed.so && \
++	ln -fs libsgx_pve.signed.so.1 libsgx_pve.signed.so && \
++	ln -fs libsgx_pce_logic.so.1  libsgx_pce_logic.so && \
++	ln -fs libsgx_pce.signed.so.1 libsgx_pce.signed.so && \
++	ln -fs libsgx_le.signed.so.1 libsgx_le.signed.so && \
++	ln -fs libsgx_id_enclave.signed.so.1 libsgx_id_enclave.signed.so

--- a/recipes-bsp/sgx/sgx_2.18.1.bb
+++ b/recipes-bsp/sgx/sgx_2.18.1.bb
@@ -13,6 +13,7 @@ DEPENDS += "protobuf-native cppmicroservices-native curl protobuf cppmicroservic
 SRC_URI += " \
     file://0031-add-sysroot-libdir-target.patch  \
     file://0032-cppmicroservices-target-build.patch \
+    file://fix_link.patch \
 "
 
 ### compile ###


### PR DESCRIPTION
For the yocto build the final shared object was with suffix as .so.1 therefore had to create a ln to the a normal .so file.