### PR TITLE
Fix ocaml compilation in ubuntu 22.04 LTS.

### DIFF
--- a/recipes-devtools/ocaml/files/0001-Fix-ocaml-compilation-in-ubuntu-22.04-LTS.patch
+++ b/recipes-devtools/ocaml/files/0001-Fix-ocaml-compilation-in-ubuntu-22.04-LTS.patch
@@ -1,0 +1,179 @@
+From a8f5b23f24a305485cf39b6bf05d15f1e1254b22 Mon Sep 17 00:00:00 2001
+From: Karn Jye Lau <karn.jye.lau@intel.com>
+Date: Thu, 22 Feb 2024 10:12:57 +0530
+Subject: [PATCH] Fix ocaml compilation in ubuntu 22.04 LTS.
+
+Upstream glibc broke ocaml compilation in ubuntu
+21 onward. Backport upstream details fixes from
+17df117b4939486d3285031900587afce5262c8c.
+This dedicated commit is intend to provide
+the build fix and address the memory leaks for
+4.08 version of ocaml.
+
+Upstream-Status: Backport.
+Reference:https://github.com/ocaml/ocaml/commit/17df117b4939486d3285031900587afce5262c8c
+
+Signed-off-by: Karn Jye Lau <karn.jye.lau@intel.com>
+---
+ runtime/fail_nat.c    |  6 +++-
+ runtime/signals_nat.c | 64 +++++++++++++++++++++++++++++++++++++------
+ runtime/startup_nat.c |  7 ++++-
+ runtime/sys.c         |  3 ++
+ 4 files changed, 69 insertions(+), 11 deletions(-)
+
+diff --git a/runtime/fail_nat.c b/runtime/fail_nat.c
+index ec5bfeb..e4373dd 100644
+--- a/runtime/fail_nat.c
++++ b/runtime/fail_nat.c
+@@ -30,6 +30,7 @@
+ #include "caml/stack.h"
+ #include "caml/roots.h"
+ #include "caml/callback.h"
++extern void caml_terminate_signals(void);
+ 
+ /* The globals holding predefined exceptions */
+ 
+@@ -60,7 +61,10 @@ char * caml_exception_pointer = NULL;
+ void caml_raise(value v)
+ {
+   Unlock_exn();
+-  if (caml_exception_pointer == NULL) caml_fatal_uncaught_exception(v);
++  if (caml_exception_pointer == NULL) {
++    caml_terminate_signals();
++    caml_fatal_uncaught_exception(v);
++  }
+ 
+   while (caml_local_roots != NULL &&
+          (char *) caml_local_roots < caml_exception_pointer) {
+diff --git a/runtime/signals_nat.c b/runtime/signals_nat.c
+index 29a5f49..cb02eba 100644
+--- a/runtime/signals_nat.c
++++ b/runtime/signals_nat.c
+@@ -182,7 +182,6 @@ DECLARE_SIGNAL_HANDLER(trap_handler)
+ #ifdef HAS_STACK_OVERFLOW_DETECTION
+ 
+ static char * system_stack_top;
+-static char sig_alt_stack[SIGSTKSZ];
+ 
+ #if defined(SYS_linux)
+ /* PR#4746: recent Linux kernels with support for stack randomization
+@@ -275,14 +274,61 @@ void caml_init_signals(void)
+   {
+     stack_t stk;
+     struct sigaction act;
+-    stk.ss_sp = sig_alt_stack;
+-    stk.ss_size = SIGSTKSZ;
+-    stk.ss_flags = 0;
+-    SET_SIGACT(act, segv_handler);
+-    act.sa_flags |= SA_ONSTACK | SA_NODEFER;
+-    sigemptyset(&act.sa_mask);
+-    system_stack_top = (char *) &act;
+-    if (sigaltstack(&stk, NULL) == 0) { sigaction(SIGSEGV, &act, NULL); }
++      /* Allocate and select an alternate stack for handling signals,
++       especially SIGSEGV signals.
++       The alternate stack used to be statically-allocated for the main thread,
++       but this is incompatible with Glibc 2.34 and newer, where SIGSTKSZ
++       may not be a compile-time constant. */
++    stk.ss_sp = malloc(SIGSTKSZ);
++    if (stk.ss_sp != NULL) {
++      stk.ss_size = SIGSTKSZ;
++      stk.ss_flags = 0;
++      SET_SIGACT(act, segv_handler);
++      act.sa_flags |= SA_ONSTACK | SA_NODEFER;
++      sigemptyset(&act.sa_mask);
++      system_stack_top = (char *) &act;
++      if (sigaltstack(&stk, NULL) == 0)
++        sigaction(SIGSEGV, &act, NULL);
++      else
++        free(stk.ss_sp);
++    }
+   }
+ #endif
+ }
++
++/* Termination of signal stuff */
++
++#if defined(TARGET_power) || defined(TARGET_s390x) \
++    || defined(HAS_STACK_OVERFLOW_DETECTION)
++static void set_signal_default(int signum)
++{
++  struct sigaction act;
++  sigemptyset(&act.sa_mask);
++  act.sa_handler = SIG_DFL;
++  act.sa_flags = 0;
++  sigaction(signum, &act, NULL);
++}
++#endif
++
++void caml_terminate_signals(void)
++{
++#if defined(TARGET_power)
++  set_signal_default(SIGTRAP);
++#endif
++
++#if defined(TARGET_s390x)
++  set_signal_default(SIGFPE);
++#endif
++
++#ifdef HAS_STACK_OVERFLOW_DETECTION
++  set_signal_default(SIGSEGV);
++  stack_t oldstk, stk;
++  stk.ss_flags = SS_DISABLE;
++  if (sigaltstack(&stk, &oldstk) == 0) {
++    /* If caml_init_signals failed, we are not using an alternate signal stack.
++       SS_DISABLE will be set in oldstk, and there is nothing to free in this
++       case. */
++    if (! (oldstk.ss_flags & SS_DISABLE)) free(oldstk.ss_sp);
++  }
++  #endif
++}
+\ No newline at end of file
+diff --git a/runtime/startup_nat.c b/runtime/startup_nat.c
+index 378b679..d6436f9 100644
+--- a/runtime/startup_nat.c
++++ b/runtime/startup_nat.c
+@@ -93,6 +93,7 @@ void (*caml_termination_hook)(void *) = NULL;
+ extern value caml_start_program (void);
+ extern void caml_init_ieee_floats (void);
+ extern void caml_init_signals (void);
++extern void caml_terminate_signals(void);
+ #ifdef _WIN32
+ extern void caml_win32_overflow_detection (void);
+ #endif
+@@ -107,6 +108,7 @@ extern void caml_install_invalid_parameter_handler();
+ value caml_startup_common(char_os **argv, int pooling)
+ {
+   char_os * exe_name, * proc_self_exe;
++  value res;
+   char tos;
+ 
+   /* Determine options */
+@@ -154,10 +156,13 @@ value caml_startup_common(char_os **argv, int pooling)
+     exe_name = caml_search_exe_in_path(exe_name);
+   caml_sys_init(exe_name, argv);
+   if (sigsetjmp(caml_termination_jmpbuf.buf, 0)) {
++    caml_terminate_signals();
+     if (caml_termination_hook != NULL) caml_termination_hook(NULL);
+     return Val_unit;
+   }
+-  return caml_start_program();
++  res = caml_start_program();
++  caml_terminate_signals();
++  return res;
+ }
+ 
+ value caml_startup_exn(char_os **argv)
+diff --git a/runtime/sys.c b/runtime/sys.c
+index c019ee9..aef85e7 100644
+--- a/runtime/sys.c
++++ b/runtime/sys.c
+@@ -155,6 +155,9 @@ CAMLprim value caml_sys_exit(value retcode_v)
+     caml_shutdown();
+ #ifdef _WIN32
+   caml_restore_win32_terminal();
++#endif
++#ifdef NATIVE_CODE
++  caml_terminate_signals();
+ #endif
+   exit(retcode);
+ }

--- a/recipes-devtools/ocaml/ocaml-native_4.08.1.bb
+++ b/recipes-devtools/ocaml/ocaml-native_4.08.1.bb
@@ -16,6 +16,7 @@ PARALLEL_MAKEINST = ""
 SRC_URI += "https://github.com/ocaml/ocaml/archive/4.08.1.tar.gz;sha256sum=b53ed3d487b83fd49bc181bded066ae8e6fb592cf40514261d27d36050d5db85"
 SRC_URI += "file://0001-4.08.1-link-error.patch"
 SRC_URI += "file://0002-4.08.1-shebang-use-env.patch"
+SRC_URI += "file://0001-Fix-ocaml-compilation-in-ubuntu-22.04-LTS.patch"
 S = "${WORKDIR}/ocaml-4.08.1"
 
 do_configure () {


### PR DESCRIPTION
Upstream glibc broke ocaml compilation in ubuntu
21 onward. Backport upstream ocaml modification
from commit:17df117b4939486d3285031900587afce5262c8c
to address the build issue and the memory leaks issue
post https://github.com/ocaml/ocaml/pull/10266  modification.