### PR TITLE
Update for the scarthgap release series

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -17,6 +17,6 @@ LAYERDEPENDS_sgx = "core openembedded-layer"
 # Override security flags
 require conf/distro/include/meta_intel_sgx_security_flags.inc
 
-LAYERSERIES_COMPAT_sgx = "gatesgarth hardknott kirkstone"
+LAYERSERIES_COMPAT_sgx = "gatesgarth hardknott kirkstone scarthgap"
 
 LICENSE_PATH += "${LAYERDIR}/custom-licenses"

--- a/recipes-bsp/sgx/files/tlibcxx-initialize-__chash-variable.patch
+++ b/recipes-bsp/sgx/files/tlibcxx-initialize-__chash-variable.patch
@@ -1,0 +1,31 @@
+From 20fb92a9b92627daed683af026610d9d1a00a48a Mon Sep 17 00:00:00 2001
+From: Preeti Sachan <preeti.sachan@intel.com>
+Date: Thu, 28 Mar 2024 11:27:25 +0530
+Subject: [PATCH] tlibcxx: initialize __chash variable
+
+initialize __chash variable to fix warning treated as error.
+errr: '__chash' may be used uninitialized [-Werror=maybe-uninitialized]
+
+Upstream-Status: Backport [https://github.com/intel/linux-sgx/commit/e7bbc158fa242cf5b5534ecb1fb2668edf5cd887]
+
+Signed-off-by: Preeti Sachan <preeti.sachan@intel.com>
+---
+ sdk/tlibcxx/include/__hash_table | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/sdk/tlibcxx/include/__hash_table b/sdk/tlibcxx/include/__hash_table
+index 521ebbf2..8c926ad8 100644
+--- a/sdk/tlibcxx/include/__hash_table
++++ b/sdk/tlibcxx/include/__hash_table
+@@ -2073,7 +2073,7 @@ __hash_table<_Tp, _Hash, _Equal, _Alloc>::__emplace_unique_key_args(_Key const&
+     size_type __bc = bucket_count();
+     bool __inserted = false;
+     __next_pointer __nd;
+-    size_t __chash;
++    size_t __chash = 0;
+     if (__bc != 0)
+     {
+         __chash = __constrain_hash(__hash, __bc);
+-- 
+2.34.1
+

--- a/recipes-bsp/sgx/files/tlibcxx-use-gcc-is_convertible-built-in-traits.patch
+++ b/recipes-bsp/sgx/files/tlibcxx-use-gcc-is_convertible-built-in-traits.patch
@@ -1,0 +1,51 @@
+From 8269162f8bb36ff0e1c1884d01e0aa7158885b72 Mon Sep 17 00:00:00 2001
+From: Preeti Sachan <preeti.sachan@intel.com>
+Date: Mon, 25 Mar 2024 12:27:55 +0530
+Subject: [PATCH] tlibcxx use std::is_convertible built-in traits
+
+GCC 13 barfs on parsing <type_traits> because of the declarations
+of `struct __is_convertible`.  In GCC 13, `__is_convertible` is a
+built-in, but `__is_convertible_to` is not.
+
+GCC v13 commit to use new built-ins for std::is_convertible traits:
+https://github.com/gcc-mirror/gcc/commit/af85ad891703db220b25e7847f10d0bbec4becf4
+
+Upstream-Status: Backport [https://github.com/intel/linux-sgx/commit/e7bbc158fa242cf5b5534ecb1fb2668edf5cd887]
+
+Signed-off-by: Preeti Sachan <preeti.sachan@intel.com>
+---
+ sdk/tlibcxx/include/type_traits | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/sdk/tlibcxx/include/type_traits b/sdk/tlibcxx/include/type_traits
+index 59dfd1e9..e4f66aa4 100644
+--- a/sdk/tlibcxx/include/type_traits
++++ b/sdk/tlibcxx/include/type_traits
+@@ -1682,12 +1682,12 @@ struct __is_core_convertible<_Tp, _Up, decltype(
+ 
+ // is_convertible
+ 
+-#if __has_feature(is_convertible_to) && !defined(_LIBCPP_USE_IS_CONVERTIBLE_FALLBACK)
++#if __has_builtin(__is_convertible) && !defined(_LIBCPP_USE_IS_CONVERTIBLE_FALLBACK)
+ 
+ template <class _T1, class _T2> struct _LIBCPP_TEMPLATE_VIS is_convertible
+-    : public integral_constant<bool, __is_convertible_to(_T1, _T2)> {};
++    : public integral_constant<bool, __is_convertible(_T1, _T2)> {};
+ 
+-#else  // __has_feature(is_convertible_to)
++#else  // __has_builtin(__is_convertible)
+ 
+ namespace __is_convertible_imp
+ {
+@@ -1754,7 +1754,7 @@ template <class _T1, class _T2> struct _LIBCPP_TEMPLATE_VIS is_convertible
+     static const size_t __complete_check2 = __is_convertible_check<_T2>::__v;
+ };
+ 
+-#endif  // __has_feature(is_convertible_to)
++#endif  // __has_builtin(__is_convertible)
+ 
+ #if _LIBCPP_STD_VER > 14 && !defined(_LIBCPP_HAS_NO_VARIABLE_TEMPLATES)
+ template <class _From, class _To>
+-- 
+2.34.1
+

--- a/recipes-bsp/sgx/sgx-sdk_2.18.1.bb
+++ b/recipes-bsp/sgx/sgx-sdk_2.18.1.bb
@@ -14,6 +14,8 @@ SRC_URI += " \
     file://0001-sdk-configure.patch              \
     file://0002-install-sysroot.patch            \
     file://0021-fix-include-path.patch           \
+    file://tlibcxx-use-gcc-is_convertible-built-in-traits.patch \
+    file://tlibcxx-initialize-__chash-variable.patch \
 "
 
 ### compile ###

--- a/recipes-devtools/cppmicroservices/cppmicroservices_4.0.bb
+++ b/recipes-devtools/cppmicroservices/cppmicroservices_4.0.bb
@@ -21,8 +21,8 @@ SRCREV = "984f3c9fe809b8d0acfb0b0934087c240ecf280f"
 # Patches
 SRC_URI:append:class-target = " file://0001-host-bin.patch \
                                "
-SRC_URI:append = " file://0001-fix-build-with-gcc-11.patch;striplevel=3"
-
+SRC_URI:append = " file://0001-fix-build-with-gcc-11.patch;striplevel=3 \
+                   file://0001-include-cstdint-header-to-fix-gcc13-build.patch;striplevel=3"
 # Source directory
 S = "${WORKDIR}/git/external/CppMicroServices"
 

--- a/recipes-devtools/cppmicroservices/files/0001-include-cstdint-header-to-fix-gcc13-build.patch
+++ b/recipes-devtools/cppmicroservices/files/0001-include-cstdint-header-to-fix-gcc13-build.patch
@@ -1,0 +1,24 @@
+From d8174e56eb2595751d75bdadb6e371eadf9405eb Mon Sep 17 00:00:00 2001
+From: kjlau0112 <karn.jye.lau@intel.com>
+Date: Fri, 8 Dec 2023 13:22:54 +0530
+Subject: [PATCH] include  <cstdint> header to fix gcc13 build.
+
+Upstream-Status: Backport [https://github.com/intel/linux-sgx/commit/cd6c2a8b81a2d70a2b2a1e7ce814bdbea9dd4732]
+
+Signed-off-by: kjlau0112 <karn.jye.lau@intel.com>
+---
+ external/CppMicroServices/util/src/FileSystem.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/external/CppMicroServices/util/src/FileSystem.cpp b/external/CppMicroServices/util/src/FileSystem.cpp
+index 3a3ffab0..650c9fbb 100644
+--- a/external/CppMicroServices/util/src/FileSystem.cpp
++++ b/external/CppMicroServices/util/src/FileSystem.cpp
+@@ -28,6 +28,7 @@
+ #include <stdexcept>
+ #include <string>
+ #include <vector>
++#include <cstdint>
+ 
+ #ifdef US_PLATFORM_POSIX
+ #  include <dirent.h>


### PR DESCRIPTION
layer.conf:
Update LAYERSERIES_COMPAT to use scarthgap.

cppmicroservices:
Fix compile error with GCC 13 & above.
Patch 0001-include-cstdint-header-to-fix-gcc13-build.patch is backported
from https://github.com/intel/linux-sgx/commit/cd6c2a8b81a2d70a2b2a1e7ce814bdbea9dd4732.

sgx-sdk:
Fix compile error with GCC 13 & above.
Patch tlibcxx-use-gcc-is_convertible-built-in-traits.patch and
tlibcxx-initialize-__chash-variable.patch are backported from
https://github.com/intel/linux-sgx/commit/e7bbc158fa242cf5b5534ecb1fb2668edf5cd887.