### PR TITLE
Update linux-sgx source on recipes.

### DIFF
--- a/recipes-bsp/sgx/sgx-source_2.18.1.inc
+++ b/recipes-bsp/sgx/sgx-source_2.18.1.inc
@@ -2,7 +2,7 @@
 ### source ###
 
 # Source repo
-SRC_URI = "gitsm://github.com/intel/linux-sgx.git;branch=master;protocol=https"
+SRC_URI = "gitsm://github.com/intel/linux-sgx.git;branch=main;protocol=https"
 SRCREV = "607a226fc38e66e9b68f12c1b8b68045a5e064f8"
 
 SRC_URI += "https://download.01.org/intel-sgx/sgx-linux/2.18.1/optimized_libs_2.18.1.tar.gz;name=optimized_libs;subdir=${S}"

--- a/recipes-devtools/cppmicroservices/cppmicroservices_4.0.bb
+++ b/recipes-devtools/cppmicroservices/cppmicroservices_4.0.bb
@@ -15,7 +15,7 @@ PARALLEL_MAKEINST = ""
 ### source ###
 
 # Source repo
-SRC_URI = "gitsm://github.com/intel/linux-sgx.git;branch=master;protocol=https"
+SRC_URI = "gitsm://github.com/intel/linux-sgx.git;branch=main;protocol=https"
 SRCREV = "984f3c9fe809b8d0acfb0b0934087c240ecf280f"
 
 # Patches


### PR DESCRIPTION
linux-sgx source have changed from master to main. Update impacted recipes to avoid yocto build
failure.