### PR TITLE
Update sgx-dcap and intelsgx source.

### DIFF
--- a/recipes-bsp/sgx/sgx-dcap_1.15.bb
+++ b/recipes-bsp/sgx/sgx-dcap_1.15.bb
@@ -18,7 +18,7 @@ D_prebuilt_dcap = "${S}/QuoteGeneration"
 D_sgxssl="${S}/QuoteVerification/sgxssl"
 D_openssl="${S}/QuoteVerification/sgxssl/openssl_source"
 
-SRC_URI  = "git://github.com/intel/SGXDataCenterAttestationPrimitives.git;protocol=https"
+SRC_URI  = "git://github.com/intel/SGXDataCenterAttestationPrimitives.git;protocol=https;branch=main"
 SRCREV = "85cf8bdd393ab273a308be3f41d2f7cc25c0ec0c"
 
 ### prebuilt sgx dcap source ###

--- a/recipes-kernel/intelsgx/intelsgx.bb
+++ b/recipes-kernel/intelsgx/intelsgx.bb
@@ -6,7 +6,7 @@ DEPENDS += " virtual/kernel"
 
 inherit module
 
-SRC_URI  = "git://github.com/intel/SGXDataCenterAttestationPrimitives.git;protocol=https"
+SRC_URI  = "git://github.com/intel/SGXDataCenterAttestationPrimitives.git;protocol=https;branch=main"
 SRC_URI += "file://build_kernel_yocto.patch"
 
 SRCREV = "98976322e8b58e23256355f5cf90b9e30e37d8c1"


### PR DESCRIPTION
SGXDataCenterAttestationPrimitives github repository master branch
was renamed to "main".
Updated recipes to include "main" branch as part of SRC_URI to fix
yocto recipe build errors.