### PR TITLE
Fix for the scarthgap release series

### DIFF
--- a/recipes-bsp/sgx/files/0001-sgx-dcap-fix-gcc-v13-build-and-absl-dependencies.patch
+++ b/recipes-bsp/sgx/files/0001-sgx-dcap-fix-gcc-v13-build-and-absl-dependencies.patch
@@ -1,0 +1,60 @@
+From df4b185c8d148ad5a763355efa7807b154751a10 Mon Sep 17 00:00:00 2001
+From: Preeti Sachan <preeti.sachan@intel.com>
+Date: Wed, 24 Apr 2024 12:21:51 +0530
+Subject: [PATCH] sgx-dcap: fix gcc v13 build and absl dependencies
+
+Fixed build issue with GCC v13 by including header '<cstdint>'.
+Protobuf v22 and later depends on abseil-cpp and abseil-cpp requires C++17.
+
+Ref:
+https://git.openembedded.org/meta-openembedded/commit/meta-oe/recipes-devtools/protobuf?id=fb34c7e3fae2ac7412dfb5920dfd1c9aca68427f
+https://protobuf.dev/support/migration/#cpp-22
+
+Upstream-Status: Backport [https://github.com/intel/SGX-TDX-DCAP-QuoteVerificationLibrary/commit/16b7291a7a86e486fdfcf1dfb4be885c0cc00b4e]
+
+Signed-off-by: Preeti Sachan <preeti.sachan@intel.com>
+---
+ QuoteGeneration/buildenv.mk                                    | 2 +-
+ QuoteGeneration/qcnl/inc/qcnl_util.h                           | 3 ++-
+ .../QVL/Src/AttestationCommons/include/OpensslHelpers/Bytes.h  | 1 +
+ 3 files changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/QuoteGeneration/buildenv.mk b/QuoteGeneration/buildenv.mk
+index 67b9e9f..e12e5c0 100644
+--- a/QuoteGeneration/buildenv.mk
++++ b/QuoteGeneration/buildenv.mk
+@@ -137,7 +137,7 @@ CFLAGS += -Wjump-misses-init -Wstrict-prototypes -Wunsuffixed-float-constants
+ # additional warnings flags for C++
+ CXXFLAGS += -Wnon-virtual-dtor
+ 
+-CXXFLAGS += -std=c++14
++CXXFLAGS += -std=c++17
+ 
+ .DEFAULT_GOAL := all
+ # this turns off the RCS / SCCS implicit rules of GNU Make
+diff --git a/QuoteGeneration/qcnl/inc/qcnl_util.h b/QuoteGeneration/qcnl/inc/qcnl_util.h
+index 26f7fb1..35df7d0 100644
+--- a/QuoteGeneration/qcnl/inc/qcnl_util.h
++++ b/QuoteGeneration/qcnl/inc/qcnl_util.h
+@@ -39,6 +39,7 @@
+ 
+ #include <string>
+ #include <unordered_map>
++#include <cstdint>
+ 
+ using namespace std;
+ 
+diff --git a/QuoteVerification/QVL/Src/AttestationCommons/include/OpensslHelpers/Bytes.h b/QuoteVerification/QVL/Src/AttestationCommons/include/OpensslHelpers/Bytes.h
+index acfe6f1..dbe742a 100644
+--- a/QuoteVerification/QVL/Src/AttestationCommons/include/OpensslHelpers/Bytes.h
++++ b/QuoteVerification/QVL/Src/AttestationCommons/include/OpensslHelpers/Bytes.h
+@@ -38,6 +38,7 @@
+ #include <string>
+ #include <algorithm>
+ #include <iterator>
++#include <cstdint>
+ 
+ namespace intel { namespace sgx { namespace dcap {
+ 
+-- 
+2.34.1

--- a/recipes-bsp/sgx/files/0001-sgx-fix-gcc-v13-build-and-absl-dependencies.patch
+++ b/recipes-bsp/sgx/files/0001-sgx-fix-gcc-v13-build-and-absl-dependencies.patch
@@ -1,0 +1,119 @@
+From bc71785920e671cf4f64f29fe15ad970cf2a14d8 Mon Sep 17 00:00:00 2001
+From: Preeti Sachan <preeti.sachan@intel.com>
+Date: Wed, 24 Apr 2024 14:44:12 +0530
+Subject: [PATCH] sgx: fix gcc v13 build and absl dependencies
+
+Fixed build issue with GCC v13 by including header '<cstdint>'.
+Protobuf v22 and later depends on abseil-cpp and abseil-cpp requires C++17.
+Find protobuf in CONFIG mode to fixe the absl dependencies.
+
+Ref:
+https://git.openembedded.org/meta-openembedded/commit/meta-oe/recipes-devtools/protobuf?id=fb34c7e3fae2ac7412dfb5920dfd1c9aca68427f
+https://protobuf.dev/support/migration/#cpp-22
+
+Upstream-Status: Pending
+
+Signed-off-by: Preeti Sachan <preeti.sachan@intel.com>
+---
+ psw/ae/aesm_service/source/CMakeLists.txt     | 14 ++++---
+ .../source/core/ipc/CMakeLists.txt            | 37 ++++++++++++-------
+ 2 files changed, 31 insertions(+), 20 deletions(-)
+
+diff --git a/psw/ae/aesm_service/source/CMakeLists.txt b/psw/ae/aesm_service/source/CMakeLists.txt
+index 07577d60..eb3c66b6 100644
+--- a/psw/ae/aesm_service/source/CMakeLists.txt
++++ b/psw/ae/aesm_service/source/CMakeLists.txt
+@@ -7,11 +7,9 @@ project(ModularAESM VERSION 0.1.0)
+ 
+ 
+ # check if protobuf was found
+-find_package(Protobuf REQUIRED)
+-if(PROTOBUF_FOUND)
+-    message ("protobuf found")
+-else()
+-    message (FATAL_ERROR "Cannot find Protobuf")
++find_package(Protobuf CONFIG QUIET)
++if (NOT Protobuf_FOUND)
++    find_package(Protobuf REQUIRED)
+ endif()
+ 
+ # check if CppMicroServices was found
+@@ -35,7 +33,11 @@ endif()
+ add_definitions("-DOPENSSL_API_COMPAT=10101")
+ 
+ set(CMAKE_CXX_STANDARD_REQUIRED 1)
+-set(CMAKE_CXX_STANDARD 11)
++if(CMAKE_VERSION VERSION_LESS "3.8")
++    set(CMAKE_CXX_STANDARD 14)
++elseif(CMAKE_VERSION VERSION_LESS "3.11")
++    set(CMAKE_CXX_STANDARD 17)
++endif()
+ set(CMAKE_SKIP_BUILD_RPATH true)
+ 
+ ########## SGX SDK Settings ##########
+diff --git a/psw/ae/aesm_service/source/core/ipc/CMakeLists.txt b/psw/ae/aesm_service/source/core/ipc/CMakeLists.txt
+index f233595d..016f2a6f 100644
+--- a/psw/ae/aesm_service/source/core/ipc/CMakeLists.txt
++++ b/psw/ae/aesm_service/source/core/ipc/CMakeLists.txt
+@@ -1,13 +1,15 @@
+ aux_source_directory(. IPC_LIB_SRCS)
+-PROTOBUF_GENERATE_CPP(PROTO_SRCS PROTO_HDRS messages.proto)
+-# Print path to generated files
+-message ("PROTO_SRCS = ${PROTO_SRCS}")
+-message ("PROTO_HDRS = ${PROTO_HDRS}")
+-list(APPEND IPC_LIB_SRCS ${PROTO_SRCS})
+-add_library (ipc ${IPC_LIB_SRCS})
++set(ipc_PROTOS messages.proto)
++if(protobuf_MODULE_COMPATIBLE)
++    PROTOBUF_GENERATE_CPP(PROTO_SRCS PROTO_HDRS ${ipc_PROTOS})
++    # Print path to generated files
++    message ("PROTO_SRCS = ${PROTO_SRCS}")
++    message ("PROTO_HDRS = ${PROTO_HDRS}")
++    list(APPEND IPC_LIB_SRCS ${PROTO_SRCS} ${PROTO_HDRS})
++endif()
++add_library (ipc ${IPC_LIB_SRCS} ${ipc_PROTOS})
+ target_include_directories(ipc
+     PUBLIC
+-    ${PROTOBUF_INCLUDE_DIRS}
+     ${CMAKE_CURRENT_BINARY_DIR}
+     ${PROJECT_SOURCE_DIR}/common
+     ${PROJECT_SOURCE_DIR}/core/ipc
+@@ -19,10 +21,17 @@ target_include_directories(ipc
+     ${PROJECT_SOURCE_DIR}/../../../../external/dcap_source/QuoteGeneration/quote_wrapper/quote/inc
+     ${PROJECT_SOURCE_DIR}/../../../../external/dcap_source/QuoteGeneration/pce_wrapper/inc
+ )
+-
+-# link the exe against the libraries
+-target_link_libraries(ipc
+-    PUBLIC
+-    ${PROTOBUF_LIBRARIES}
+-)
+-
++if(protobuf_MODULE_COMPATIBLE) #Legacy mode
++    target_include_directories(ipc
++        PUBLIC
++        ${PROTOBUF_INCLUDE_DIRS}
++    )
++    # link the exe against the libraries
++    target_link_libraries(ipc
++        PUBLIC
++        ${PROTOBUF_LIBRARIES}
++    )
++else()
++    target_link_libraries(ipc protobuf::libprotobuf)
++    PROTOBUF_GENERATE(TARGET ipc)
++endif()
+diff --git a/external/dcap_source/QuoteGeneration/qcnl/inc/qcnl_util.h b/external/dcap_source/QuoteGeneration/qcnl/inc/qcnl_util.h
+index 26f7fb1..cdd7921 100644
+--- a/external/dcap_source/QuoteGeneration/qcnl/inc/qcnl_util.h
++++ b/external/dcap_source/QuoteGeneration/qcnl/inc/qcnl_util.h
+@@ -39,6 +39,7 @@
+
+ #include <string>
+ #include <unordered_map>
++#include <cstdint>
+
+ using namespace std;
+
+-- 
+2.34.1

--- a/recipes-bsp/sgx/sgx-dcap_1.15.bb
+++ b/recipes-bsp/sgx/sgx-dcap_1.15.bb
@@ -22,7 +22,8 @@ SRC_URI  = "git://github.com/intel/SGXDataCenterAttestationPrimitives.git;protoc
 SRCREV = "85cf8bdd393ab273a308be3f41d2f7cc25c0ec0c"
 
 ### prebuilt sgx dcap source ###
-SRC_URI += "https://download.01.org/intel-sgx/sgx-dcap/1.15/linux/prebuilt_dcap_1.15.tar.gz;name=prebuilt_dcap;subdir=${D_prebuilt_dcap}"
+SRC_URI += "https://download.01.org/intel-sgx/sgx-dcap/1.15/linux/prebuilt_dcap_1.15.tar.gz;name=prebuilt_dcap;subdir=${D_prebuilt_dcap} \
+            file://0001-sgx-dcap-fix-gcc-v13-build-and-absl-dependencies.patch"
 SRC_URI[prebuilt_dcap.sha256sum] = "b7a16cd939ec632363bb69f8df0bf60835d06adafb70e15ba341ef4e1d37ed36"
 
 ### configure sgxssl ###

--- a/recipes-bsp/sgx/sgx-sdk-cross_2.18.1.bb
+++ b/recipes-bsp/sgx/sgx-sdk-cross_2.18.1.bb
@@ -40,6 +40,18 @@ do_install () {
         cd ${D}${sgxdirprefix}${sgxsdkpath}-cross/lib64
         ln -sf libsgx_urts.so libsgx_urts.so.2
     fi
+    # Fix for qa check buildpaths that contains reference to TMPDIR. Files .pc have
+    # TMPDIR "<absolute-path>/build/tmp-*/work/x86_64-linux/sgx-sdk-cross/2.18.1/recipe-sysroot-native/opt/intel/sgxsdk" in path to prefix variable.
+    sed -i -e 's#${D}${STAGING_DIR_NATIVE}##g' ${D}${sgxdirprefix}${sgxsdkpath}-cross/pkgconfig/libsgx_quote_ex.pc
+    sed -i -e 's#${D}${STAGING_DIR_NATIVE}##g' ${D}${sgxdirprefix}${sgxsdkpath}-cross/pkgconfig/libsgx_epid_sim.pc
+    sed -i -e 's#${D}${STAGING_DIR_NATIVE}##g' ${D}${sgxdirprefix}${sgxsdkpath}-cross/pkgconfig/libsgx_urts_sim.pc
+    sed -i -e 's#${D}${STAGING_DIR_NATIVE}##g' ${D}${sgxdirprefix}${sgxsdkpath}-cross/pkgconfig/libsgx_epid.pc
+    sed -i -e 's#${D}${STAGING_DIR_NATIVE}##g' ${D}${sgxdirprefix}${sgxsdkpath}-cross/pkgconfig/libsgx_launch_sim.pc
+    sed -i -e 's#${D}${STAGING_DIR_NATIVE}##g' ${D}${sgxdirprefix}${sgxsdkpath}-cross/pkgconfig/libsgx_launch.pc
+    sed -i -e 's#${D}${STAGING_DIR_NATIVE}##g' ${D}${sgxdirprefix}${sgxsdkpath}-cross/pkgconfig/libsgx_uae_service_sim.pc
+    sed -i -e 's#${D}${STAGING_DIR_NATIVE}##g' ${D}${sgxdirprefix}${sgxsdkpath}-cross/pkgconfig/libsgx_uae_service.pc
+    sed -i -e 's#${D}${STAGING_DIR_NATIVE}##g' ${D}${sgxdirprefix}${sgxsdkpath}-cross/pkgconfig/libsgx_quote_ex_sim.pc
+    sed -i -e 's#${D}${STAGING_DIR_NATIVE}##g' ${D}${sgxdirprefix}${sgxsdkpath}-cross/pkgconfig/libsgx_urts.pc
 }
 
 ### ###

--- a/recipes-bsp/sgx/sgx_2.18.1.bb
+++ b/recipes-bsp/sgx/sgx_2.18.1.bb
@@ -15,6 +15,7 @@ SRC_URI += " \
     file://0032-cppmicroservices-target-build.patch \
     file://fix_link.patch \
     file://fix-aesm_service-cross-compilation.patch \
+    file://0001-sgx-fix-gcc-v13-build-and-absl-dependencies.patch \
 "
 
 ### compile ###

--- a/recipes-devtools/cppmicroservices/cppmicroservices_4.0.bb
+++ b/recipes-devtools/cppmicroservices/cppmicroservices_4.0.bb
@@ -63,3 +63,5 @@ FILES:${PN} = "${bindir} ${libdir} ${datadir}"
 
 BBCLASSEXTEND = "native"
 
+# File /usr/include/cppmicroservices4/cppmicroservices/FrameworkConfig.h in package cppmicroservices-dev contains reference to TMPDIR [buildpaths]
+INSANE_SKIP:${PN}-dev += "buildpaths"

--- a/recipes-kernel/isgx/isgx.bb
+++ b/recipes-kernel/isgx/isgx.bb
@@ -6,7 +6,7 @@ DEPENDS += " virtual/kernel"
 
 inherit module
 
-SRC_URI = "git://github.com/intel/linux-sgx-driver.git \
+SRC_URI = "git://github.com/intel/linux-sgx-driver.git;protocol=https;branch=main \
            file://isgx_Makefile_for_yocto_build.patch \
           "
 


### PR DESCRIPTION
sgx:
Fixed build issue with GCC v13 by including header 'cstdint'. Protobuf v22 and later depends on abseil-cpp and abseil-cpp requires C++17. Find protobuf in CONFIG mode to fixe the absl dependencies.

sgx-dcap:
Fixed build issue with GCC v13 by including header 'cstdint'. Protobuf v22 and later depends on abseil-cpp and abseil-cpp requires C++17.

sgx-sdk-cross:
Fixed QA check buildpaths error that contains reference to TMPDIR.

cppmicroservices:
Fixed QA check buildpaths warning that contains reference to TMPDIR.

isgx:
Fixed warning message for protocol=https and branch parameters in url.